### PR TITLE
Explicitly add `$temp_file` to the `cmd`

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -6,7 +6,7 @@ import json
 
 
 class Revive(Linter):
-    cmd = ("revive", "-formatter", "ndjson", "${args}")
+    cmd = ("revive", "-formatter", "ndjson", "${args}", "${temp_file}")
     regex = r".*"
     multiline = False
     default_type = WARNING


### PR DESCRIPTION
Although SublimeLinter will still add the temporary filename to the `cmd`, it will also emit a deprecation warning in doing so.

Append manually to be future safe.